### PR TITLE
Issue 482: Fix Resource Get Statistics button

### DIFF
--- a/resources/ajax_htmldata/getRightPanel.php
+++ b/resources/ajax_htmldata/getRightPanel.php
@@ -119,7 +119,7 @@
 				<div class='rightPanelHeader'><?php echo _("Usage Statistics Module");?></div>
 
 				<?php
-			echo "<form method='post' action='/reports/report.php' target='_blank'>";
+			echo "<form method='post' action='../reports/report.php' target='_blank'>";
 			echo "<input type='hidden' name='reportID' value='1'>";
 			echo "<input type='hidden' name='prm_3' value='".$resource->titleText."'>";
 			echo "<input type='submit' value='"._("Get Statistics")."'>";


### PR DESCRIPTION
Fix the Get Statistics button on a resource page using an absolute URL (/reports/report.php) instead of a relative URL (../reports/report.php) which assumes that coral is installed in the root directory.